### PR TITLE
Implement sidebar news fetching and frontend updates

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "bulma": "^1.0.4",
+        "d3": "^7.9.0",
         "vue": "^3.5.30"
       },
       "devDependencies": {
@@ -535,11 +536,431 @@
       "integrity": "sha512-Ffb6YGXDiZYX3cqvSbHWqQ8+LkX6tVoTcZuVB3lm93sbAVXlO0D6QlOTMnV6g18gILpAXqkG2z9hf9z4hCjz2g==",
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -600,6 +1021,27 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -938,6 +1380,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
@@ -977,6 +1425,18 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
       "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bulma": "^1.0.4",
+    "d3": "^7.9.0",
     "vue": "^3.5.30"
   },
   "devDependencies": {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,73 @@
 <script setup>
-import HelloWorld from './components/HelloWorld.vue'
+import { ref } from 'vue'
+import WorldMap from './components/WorldMap.vue'
+
+const selectedCountry = ref(null)
+
+const handleCountrySelection = (countryId) => {
+  console.log('Country selected:', countryId)
+  selectedCountry.value = countryId
+  // In the next task, we will fetch news using this ID!
+}
 </script>
 
 <template>
-  <HelloWorld />
+  <div class="app-container">
+    <!-- Navigation Bar -->
+    <nav class="navbar is-primary" role="navigation" aria-label="main navigation">
+      <div class="navbar-brand">
+        <a class="navbar-item" href="/">
+          <h1 class="title is-4 has-text-white mb-0">World News Sentiment Map</h1>
+        </a>
+      </div>
+    </nav>
+
+    <!-- Main Content -->
+    <section class="section pt-4">
+      <div class="container is-fluid px-5">
+        
+        <div class="columns is-desktop is-variable is-6">
+          
+          <!-- Map Section -->
+          <div class="column is-8-desktop is-12-tablet">
+            <div class="has-text-centered mb-4">
+              <h2 class="title is-2 has-text-grey-dark mb-2">Global Sentiment</h2>
+              <p class="subtitle is-5 has-text-grey">Click on a country to view trending news.</p>
+            </div>
+            
+            <WorldMap @countrySelected="handleCountrySelection" />
+          </div>
+
+          <!-- News Feed Sidebar Placeholder -->
+          <div class="column is-4-desktop is-12-tablet mt-6">
+            <div class="box has-background-black-bis has-text-white trending-news-box">
+              <h3 class="title is-4 has-text-white has-text-centered">Trending News</h3>
+              <p v-if="!selectedCountry" class="has-text-grey-light has-text-centered">Select a country on the map to display news articles here.</p>
+              <p v-else class="has-text-primary has-text-weight-bold has-text-centered">Fetching news for: {{ selectedCountry }}...</p>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+  </div>
 </template>
+
+<style>
+/* Global resets or overrides if needed */
+html, body {
+  background-color: #f0f2f5;
+  height: 100%;
+}
+
+.app-container {
+  min-height: 100vh;
+}
+
+.trending-news-box {
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+  min-height: 200px;
+}
+</style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,71 +3,399 @@ import { ref } from 'vue'
 import WorldMap from './components/WorldMap.vue'
 
 const selectedCountry = ref(null)
+const articles = ref([])
+const isLoading = ref(false)
 
-const handleCountrySelection = (countryId) => {
+const handleCountrySelection = async (countryId) => {
   console.log('Country selected:', countryId)
   selectedCountry.value = countryId
-  // In the next task, we will fetch news using this ID!
+  isLoading.value = true
+  articles.value = []
+  
+  try {
+    const res = await fetch(`http://localhost:3000/api/news/${countryId}`)
+    const data = await res.json()
+    articles.value = data.articles || []
+  } catch (err) {
+    console.error("Failed to fetch news:", err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const getSentimentClass = (category) => {
+  if (category === 'Positive') return 'positive-news';
+  if (category === 'Negative') return 'negative-news';
+  return 'neutral-news';
+}
+
+const getSentimentTagClass = (category) => {
+  if (category === 'Positive') return 'is-success';
+  if (category === 'Negative') return 'is-danger';
+  return 'is-dark';
 }
 </script>
 
 <template>
-  <div class="app-container">
-    <!-- Navigation Bar -->
-    <nav class="navbar is-primary" role="navigation" aria-label="main navigation">
-      <div class="navbar-brand">
-        <a class="navbar-item" href="/">
-          <h1 class="title is-4 has-text-white mb-0">World News Sentiment Map</h1>
-        </a>
+  <div class="dashboard">
+    <!-- Left Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <h1 class="title is-5 has-text-white mb-0 title-text">World News Sentiment</h1>
       </div>
-    </nav>
+      <p class="menu-label px-4 mt-5 has-text-grey-light">LIVE INTELLIGENCE</p>
+      <ul class="menu-list px-2 mt-2">
+        <li><a class="is-active">Global View</a></li>
+        <li><a>Trending</a></li>
+        <li><a>Sentiment</a></li>
+        <li><a>Archive</a></li>
+      </ul>
+    </aside>
 
     <!-- Main Content -->
-    <section class="section pt-4">
-      <div class="container is-fluid px-5">
+    <main class="main-content">
+      <!-- Top Navbar (Categories) -->
+      <nav class="top-nav">
+        <div class="nav-links">
+          <a href="#" class="is-active">Technology</a>
+          <a href="#">Sports</a>
+          <a href="#">Business</a>
+          <a href="#">Finance</a>
+          <a href="#">Health</a>
+        </div>
+      </nav>
+
+      <!-- Dashboard Grid -->
+      <div class="dashboard-grid">
         
-        <div class="columns is-desktop is-variable is-6">
-          
-          <!-- Map Section -->
-          <div class="column is-8-desktop is-12-tablet">
-            <div class="has-text-centered mb-4">
-              <h2 class="title is-2 has-text-grey-dark mb-2">Global Sentiment</h2>
-              <p class="subtitle is-5 has-text-grey">Click on a country to view trending news.</p>
-            </div>
-            
+        <!-- Top Stats (Dummy data to match design) -->
+        <div class="stat-cards">
+          <div class="stat-card positive">
+            <p class="heading">GLOBAL SENTIMENT</p>
+            <p class="title has-text-success">74% Positive</p>
+          </div>
+          <div class="stat-card negative">
+            <p class="heading">ECONOMIC ALERT</p>
+            <p class="title" style="color: #ff8e8b;">12% Negative</p>
+          </div>
+          <div class="stat-card neutral">
+            <p class="heading">NEUTRAL VOLUME</p>
+            <p class="title has-text-grey-light">14% Stable</p>
+          </div>
+          <div class="stat-card active">
+            <p class="heading">ACTIVE STORIES</p>
+            <p class="title has-text-primary">2.4k Items</p>
+          </div>
+        </div>
+
+        <div class="content-split">
+          <!-- Map Area -->
+          <div class="map-area">
             <WorldMap @countrySelected="handleCountrySelection" />
           </div>
 
-          <!-- News Feed Sidebar Placeholder -->
-          <div class="column is-4-desktop is-12-tablet mt-6">
-            <div class="box has-background-black-bis has-text-white trending-news-box">
-              <h3 class="title is-4 has-text-white has-text-centered">Trending News</h3>
-              <p v-if="!selectedCountry" class="has-text-grey-light has-text-centered">Select a country on the map to display news articles here.</p>
-              <p v-else class="has-text-primary has-text-weight-bold has-text-centered">Fetching news for: {{ selectedCountry }}...</p>
+          <!-- Trending News Sidebar -->
+          <div class="news-area box has-background-black-ter mb-0">
+            <div class="news-header">
+              <h3 class="title is-5 has-text-white mb-0">Trending Now</h3>
+            </div>
+            
+            <div class="news-feed">
+              <p v-if="!selectedCountry" class="has-text-grey is-size-6 mt-4">Select a country on the map to display its local news.</p>
+              
+              <div v-else-if="isLoading" class="has-text-centered mt-6">
+                <div class="loader is-loading mx-auto mb-3" style="width: 3rem; height: 3rem; border-color: #48c774; border-right-color: transparent;"></div>
+                <p class="has-text-primary has-text-weight-bold is-size-7">Fetching local news for {{ selectedCountry }}...</p>
+              </div>
+
+              <div v-else-if="articles.length === 0" class="has-text-centered mt-6">
+                <p class="has-text-grey-light is-size-6">No recent news found for this country.</p>
+              </div>
+
+              <TransitionGroup name="list" tag="div" v-else>
+                <a 
+                  v-for="(article, index) in articles" 
+                  :key="index"
+                  :href="article.url" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  class="news-card-link"
+                >
+                  <div class="news-card" :class="getSentimentClass(article.sentimentCategory)">
+                     <div class="news-meta mb-2">
+                        <span class="has-text-grey-light">NEWS UPDATE</span>
+                        <span class="tag is-light is-pulled-right is-small" :class="getSentimentTagClass(article.sentimentCategory)">
+                          {{ article.sentimentCategory.toUpperCase() }}
+                        </span>
+                     </div>
+                     <h4 class="title is-6 has-text-white mb-2">{{ article.title }}</h4>
+                     <div v-if="article.image" class="card-image mb-2">
+                        <figure class="image is-2by1">
+                          <img :src="article.image" alt="Article image" style="object-fit: cover; border-radius: 4px;">
+                        </figure>
+                     </div>
+                     <p class="has-text-grey-light is-size-7 line-clamp-3">{{ article.summary }}</p>
+                  </div>
+                </a>
+              </TransitionGroup>
             </div>
           </div>
-
         </div>
       </div>
-    </section>
+    </main>
   </div>
 </template>
 
 <style>
-/* Global resets or overrides if needed */
+/* Global Resets */
+:root {
+  --bg-dark: #0b1120;
+  --bg-panel: #161e2e;
+  --bg-panel-light: #1f2937;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --border-color: #2d3748;
+}
+
 html, body {
-  background-color: #f0f2f5;
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  height: 100vh;
+  overflow: hidden; /* Prevent scrolling on the body! */
+}
+
+/* Layout */
+.dashboard {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* Sidebar */
+.sidebar {
+  width: 280px;
+  background-color: var(--bg-panel);
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.sidebar-header {
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.title-text {
+  text-align: center;
+  line-height: 1.3;
+  width: 100%;
+}
+
+.menu-list a {
+  color: var(--text-muted);
+  padding: 0.85em 1.5rem;
+  border-radius: 0;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.menu-list a:hover {
+  background-color: rgba(255,255,255,0.05);
+  color: var(--text-main);
+}
+
+.menu-list a.is-active {
+  background-color: rgba(72, 199, 116, 0.1);
+  color: #48c774;
+  border-left: 3px solid #48c774;
+}
+
+/* Main Content Area */
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background-color: var(--bg-dark);
+}
+
+/* Top Navbar */
+.top-nav {
+  height: 70px;
+  display: flex;
+  align-items: center;
+  padding: 0 2rem;
+  border-bottom: 1px solid var(--border-color);
+  background-color: var(--bg-dark);
+  flex-shrink: 0;
+}
+
+.nav-links a {
+  color: var(--text-muted);
+  margin-right: 2rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: color 0.2s;
+}
+
+.nav-links a:hover, .nav-links a.is-active {
+  color: var(--text-main);
+}
+
+/* Dashboard Grid */
+.dashboard-grid {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+/* Top Stats */
+.stat-cards {
+  display: flex;
+  gap: 1.5rem;
+  flex-shrink: 0;
+}
+
+.stat-card {
+  flex: 1;
+  background-color: var(--bg-panel);
+  border-radius: 8px;
+  padding: 1.25rem;
+  border-left: 4px solid var(--border-color);
+}
+
+.stat-card.positive { border-left-color: #48c774; }
+.stat-card.negative { border-left-color: #ff8e8b; }
+.stat-card.neutral { border-left-color: #6c757d; }
+.stat-card.active { border-left-color: #00d1b2; }
+
+.stat-card .heading {
+  color: var(--text-muted);
+  letter-spacing: 1.5px;
+  font-size: 0.7rem;
+  margin-bottom: 0.5rem;
+}
+
+.stat-card .title {
+  font-size: 1.75rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+/* Map and News Split */
+.content-split {
+  flex: 1;
+  display: flex;
+  gap: 1.5rem;
+  min-height: 0; /* Crucial for inner scrolling to work */
+}
+
+.map-area {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  min-height: 0; /* Let map container shrink */
+}
+
+/* Override WorldMap.vue internal spacing so it fills the map-area entirely */
+.map-area > .map-wrapper {
   height: 100%;
 }
 
-.app-container {
-  min-height: 100vh;
+.news-area {
+  flex: 1;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-width: 450px;
+  border: 1px solid var(--border-color);
 }
 
-.trending-news-box {
-  border-radius: 12px;
-  padding: 2rem;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-  min-height: 200px;
+.news-header {
+  padding: 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.news-feed {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem;
+  /* Custom Scrollbar for dark theme */
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-color) transparent;
+}
+
+.news-feed::-webkit-scrollbar {
+  width: 6px;
+}
+.news-feed::-webkit-scrollbar-thumb {
+  background-color: var(--border-color);
+  border-radius: 3px;
+}
+
+.news-card {
+  background-color: var(--bg-panel-light);
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  border-left: 3px solid var(--border-color);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.news-card-link {
+  display: block;
+  text-decoration: none;
+}
+
+.news-card-link:hover .news-card {
+  background-color: #2a3441;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.3);
+}
+
+.news-card.positive-news { border-left-color: #48c774; }
+.news-card.negative-news { border-left-color: #ff8e8b; }
+.news-card.neutral-news { border-left-color: #6c757d; }
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;  
+  overflow: hidden;
+}
+
+/* Vue TransitionGroup Classes */
+.list-enter-active,
+.list-leave-active {
+  transition: all 0.5s ease;
+}
+.list-enter-from,
+.list-leave-to {
+  opacity: 0;
+  transform: translateX(30px);
+}
+
+.news-meta {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 </style>

--- a/frontend/src/components/WorldMap.vue
+++ b/frontend/src/components/WorldMap.vue
@@ -1,0 +1,266 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+import * as d3 from 'd3'
+
+const mapContainer = ref(null)
+
+// Define Vue events we can emit to the parent
+const emit = defineEmits(['countrySelected'])
+
+// Define color scale based on sentiment
+const colorScale = {
+  'Positive': '#48c774', // Bulma success (green)
+  'Negative': '#f14668', // Bulma danger (red)
+  'Neutral': '#a1a1a1',  // Grey
+  'NoData': '#e0e0e0'    // Light grey for empty
+}
+
+// Variables to hold D3 objects for zoom buttons
+let svgSelection = null
+let zoomBehavior = null
+
+onMounted(async () => {
+  if (!mapContainer.value) return
+
+  try {
+    // Load the SVG file using D3
+    const xml = await d3.xml('/world.svg')
+    
+    // Extract the <svg> element
+    const svgNode = xml.documentElement
+    
+    // Select the container and append the SVG
+    const container = d3.select(mapContainer.value)
+    container.node().appendChild(svgNode)
+    
+    // Select the appended SVG to apply responsive styling
+    const svg = container.select('svg')
+    svgSelection = svg
+    
+    const currentWidth = svg.attr('width') || 2000
+    const currentHeight = svg.attr('height') || 1000
+    const viewBox = svg.attr('viewBox')
+    
+    if (!viewBox) {
+        svg.attr('viewBox', `0 0 ${currentWidth} ${currentHeight}`)
+    }
+    
+    svg.attr('width', '100%')
+       .attr('height', 'auto')
+       .style('max-height', '80vh') // keep it from getting too tall
+       .style('display', 'block')
+       .style('margin', '0 auto')
+
+    // Prepare for Zooming: Wrap all paths in a <g> tag if they aren't already
+    // Or just group them all into a new g tag
+    const paths = svg.selectAll('path')
+    
+    // Create a group and move all paths into it
+    const g = svg.append('g').attr('class', 'map-group')
+    paths.each(function() {
+      g.node().appendChild(this)
+    })
+       
+    // Set base style
+    g.selectAll('path')
+       .style('fill', colorScale.NoData)
+       .style('stroke', '#ffffff')
+       .style('stroke-width', '0.5px')
+       // We use CSS transition for smoother hover effects
+       .style('transition', 'fill 0.5s ease, filter 0.2s ease, transform 0.2s ease')
+
+    // Fetch sentiment summary data
+    const response = await fetch('http://localhost:3000/api/news/summary')
+    const data = await response.json()
+    const sentiments = data.sentiments || {}
+
+    // Apply colors using D3 transitions
+    g.selectAll('path')
+       .transition()
+       .duration(1000) // smooth 1-second transition
+       .style('fill', function() {
+           const pathId = d3.select(this).attr('id');
+           if (pathId && sentiments[pathId]) {
+               return colorScale[sentiments[pathId]];
+           }
+           return colorScale.NoData;
+       })
+
+    // Setup Tooltip
+    // Create a div for the tooltip and append to body
+    const tooltip = d3.select('body')
+      .append('div')
+      .attr('class', 'd3-tooltip')
+      .style('position', 'absolute')
+      .style('background-color', 'rgba(0, 0, 0, 0.8)')
+      .style('color', 'white')
+      .style('padding', '8px 12px')
+      .style('border-radius', '4px')
+      .style('font-size', '14px')
+      .style('pointer-events', 'none')
+      .style('opacity', 0)
+      .style('z-index', 1000)
+
+    // Add interactivity
+    g.selectAll('path')
+       .on('mouseover', function(event, d) {
+           // Pop out effect: bring to front to avoid overlapping clipping
+           this.parentNode.appendChild(this);
+           
+           // Apply visual pop
+           d3.select(this)
+             .style('filter', 'drop-shadow(0px 4px 6px rgba(0,0,0,0.4))')
+             .style('transform', 'translateY(-2px)');
+
+           // Get country name from aria-label or id
+           const countryName = d3.select(this).attr('aria-label') || d3.select(this).attr('id');
+           
+           tooltip.transition().duration(200).style('opacity', 1);
+           tooltip.html(`<strong>${countryName}</strong>`)
+                  .style('left', (event.pageX + 15) + 'px')
+                  .style('top', (event.pageY - 28) + 'px');
+       })
+       .on('mousemove', function(event) {
+           // Move tooltip with mouse
+           tooltip.style('left', (event.pageX + 15) + 'px')
+                  .style('top', (event.pageY - 28) + 'px');
+       })
+       .on('mouseout', function(event, d) {
+           // Revert visual pop
+           d3.select(this)
+             .style('filter', 'none')
+             .style('transform', 'none');
+             
+           // Hide tooltip
+           tooltip.transition().duration(500).style('opacity', 0);
+       })
+       .on('click', function(event, d) {
+           const countryId = d3.select(this).attr('id');
+           if (countryId) {
+             // Emit the Vue event!
+             emit('countrySelected', countryId);
+           }
+       });
+
+    // Zoom behavior
+    zoomBehavior = d3.zoom()
+      .scaleExtent([1, 8])
+      .on('zoom', (event) => {
+        g.attr('transform', event.transform);
+      });
+
+    svg.call(zoomBehavior);
+
+  } catch (error) {
+    console.error("Error loading SVG map or fetching data:", error)
+  }
+})
+
+// Programmatic zoom functions
+const handleZoomIn = () => {
+  if (svgSelection && zoomBehavior) {
+    svgSelection.transition().duration(300).call(zoomBehavior.scaleBy, 1.3);
+  }
+}
+
+const handleZoomOut = () => {
+  if (svgSelection && zoomBehavior) {
+    svgSelection.transition().duration(300).call(zoomBehavior.scaleBy, 0.77);
+  }
+}
+
+const handleReset = () => {
+  if (svgSelection && zoomBehavior) {
+    svgSelection.transition().duration(750).call(zoomBehavior.transform, d3.zoomIdentity);
+  }
+}
+</script>
+
+<template>
+  <div class="map-wrapper box">
+    <div class="map-header">
+      <div class="legend">
+        <span class="legend-item"><span class="legend-color" style="background-color: #48c774;"></span> Positive</span>
+        <span class="legend-item"><span class="legend-color" style="background-color: #f14668;"></span> Negative</span>
+        <span class="legend-item"><span class="legend-color" style="background-color: #a1a1a1;"></span> Neutral</span>
+        <span class="legend-item"><span class="legend-color" style="background-color: #e0e0e0;"></span> No Data</span>
+      </div>
+      <div class="zoom-controls buttons has-addons mb-0">
+        <button class="button is-small" @click="handleZoomIn" title="Zoom In">
+          <strong>+</strong>
+        </button>
+        <button class="button is-small" @click="handleZoomOut" title="Zoom Out">
+          <strong>-</strong>
+        </button>
+        <button class="button is-small is-light" @click="handleReset" title="Reset Map">
+          Reset
+        </button>
+      </div>
+    </div>
+    <div ref="mapContainer" class="world-map"></div>
+  </div>
+</template>
+
+<style scoped>
+.map-wrapper {
+  width: 100%;
+  padding: 1.5rem;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.map-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #eee;
+}
+
+.legend {
+  display: flex;
+  justify-content: flex-start;
+  gap: 1.5rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #4a4a4a;
+}
+
+.legend-color {
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  margin-right: 8px;
+  border-radius: 3px;
+}
+
+.world-map {
+  width: 100%;
+  /* This prevents panning from dragging the whole page on mobile */
+  touch-action: none;
+}
+
+/* Hover style managed by D3 now, but cursor can stay here */
+:deep(path) {
+  cursor: pointer;
+  outline: none;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@media screen and (max-width: 768px) {
+  .map-header {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+</style>

--- a/frontend/src/components/WorldMap.vue
+++ b/frontend/src/components/WorldMap.vue
@@ -46,8 +46,7 @@ onMounted(async () => {
     }
     
     svg.attr('width', '100%')
-       .attr('height', 'auto')
-       .style('max-height', '80vh') // keep it from getting too tall
+       .attr('height', '100%')
        .style('display', 'block')
        .style('margin', '0 auto')
 
@@ -144,12 +143,17 @@ onMounted(async () => {
 
     // Zoom behavior
     zoomBehavior = d3.zoom()
-      .scaleExtent([1, 8])
+      .scaleExtent([0.5, 8])
       .on('zoom', (event) => {
         g.attr('transform', event.transform);
       });
 
     svg.call(zoomBehavior);
+
+    // Initial transform to fit the map in the container
+    // Shift slightly to the right and substantially UP so the bottom isn't cut off.
+    const initialTransform = d3.zoomIdentity.translate(200, 10).scale(0.55);
+    svg.call(zoomBehavior.transform, initialTransform);
 
   } catch (error) {
     console.error("Error loading SVG map or fetching data:", error)
@@ -171,7 +175,8 @@ const handleZoomOut = () => {
 
 const handleReset = () => {
   if (svgSelection && zoomBehavior) {
-    svgSelection.transition().duration(750).call(zoomBehavior.transform, d3.zoomIdentity);
+    const initialTransform = d3.zoomIdentity.translate(200, 10).scale(0.55);
+    svgSelection.transition().duration(750).call(zoomBehavior.transform, initialTransform);
   }
 }
 </script>
@@ -203,6 +208,9 @@ const handleReset = () => {
 
 <style scoped>
 .map-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   padding: 1.5rem;
   background-color: #ffffff;
@@ -210,6 +218,7 @@ const handleReset = () => {
   box-shadow: 0 10px 30px rgba(0,0,0,0.08);
   position: relative;
   overflow: hidden;
+  margin-bottom: 0;
 }
 
 .map-header {
@@ -219,6 +228,7 @@ const handleReset = () => {
   margin-bottom: 1.5rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid #eee;
+  flex-shrink: 0;
 }
 
 .legend {
@@ -245,7 +255,8 @@ const handleReset = () => {
 
 .world-map {
   width: 100%;
-  /* This prevents panning from dragging the whole page on mobile */
+  flex: 1;
+  min-height: 0; /* allows shrinking in flexbox */
   touch-action: none;
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -157,11 +157,9 @@ code {
 }
 
 #app {
-  width: 1126px;
-  max-width: 100%;
+  width: 100%;
   margin: 0 auto;
   text-align: center;
-  border-inline: 1px solid var(--border);
   min-height: 100svh;
   display: flex;
   flex-direction: column;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "sentiment": "^5.0.2"
       },
       "devDependencies": {
         "concurrently": "^9.2.1",
@@ -1214,6 +1215,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/sentiment": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sentiment/-/sentiment-5.0.2.tgz",
+      "integrity": "sha512-ZeC3y0JsOYTdwujt5uOd7ILJNilbgFzUtg/LEG4wUv43LayFNLZ28ec8+Su+h3saHlJmIwYxBzfDHHZuiMA15g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "sentiment": "^5.0.2"
   },
   "devDependencies": {
     "concurrently": "^9.2.1",

--- a/routes/news.js
+++ b/routes/news.js
@@ -1,10 +1,80 @@
 const express = require('express');
 const router = express.Router();
+const fs = require('fs');
+const path = require('path');
+const { analyzeSentiment } = require('../utils/sentiment');
+
+// Allowed categories per NewsData.io documentation
+const ALLOWED_CATEGORIES = [
+    'business', 'entertainment', 'environment', 'food', 'health', 
+    'politics', 'science', 'sports', 'technology', 'top', 'tourism', 'world'
+];
+
+// Bulk sentiment endpoint for coloring the map
+router.get('/summary', async (req, res) => {
+    try {
+        let category = req.query.category ? req.query.category.toLowerCase() : null;
+        if (category && !ALLOWED_CATEGORIES.includes(category)) {
+            return res.status(400).json({ error: 'Invalid category.' });
+        }
+
+        // To prevent hitting API rate limits for all 200+ countries, we use a generated mock summary.
+        // In a real production app, this would query a database of cached recent news.
+        const countries = ['US', 'CA', 'GB', 'AU', 'IN', 'FR', 'DE', 'JP', 'BR', 'ZA', 'RU', 'CN', 'IT', 'MX', 'KR', 'ES', 'ID', 'SA', 'TR', 'AR'];
+        
+        const summary = {};
+        
+        countries.forEach(country => {
+            // Generate a random score between -5 and 5 to simulate sentiment
+            // Seed it slightly with the country string length and category so it's deterministic but varies
+            const seed = (country.charCodeAt(0) + (category ? category.length : 0)) % 3;
+            let categoryStr = 'Neutral';
+            if (seed === 0) categoryStr = 'Negative';
+            if (seed === 1) categoryStr = 'Positive';
+            
+            summary[country] = categoryStr;
+        });
+
+        res.json({ sentiments: summary });
+    } catch (error) {
+        console.error('Error in /api/news/summary route:', error);
+        res.status(500).json({ error: 'Internal server error.' });
+    }
+});
 
 router.get('/:country', async (req, res) => {
     try {
-        // NewsData.io expects lowercase 2-letter country codes
         const country = req.params.country.toLowerCase();
+        let category = req.query.category ? req.query.category.toLowerCase() : null;
+
+        // Validate category if provided
+        if (category && !ALLOWED_CATEGORIES.includes(category)) {
+            return res.status(400).json({ 
+                error: `Invalid category. Allowed categories are: ${ALLOWED_CATEGORIES.join(', ')}` 
+            });
+        }
+
+        // Check if we should use mock data
+        if (process.env.USE_MOCK_DATA === 'true') {
+            const categoryLog = category ? ` (Category: ${category})` : '';
+            console.log(`Serving MOCK news data for ${country}${categoryLog}...`);
+            const mockDataPath = path.join(__dirname, '../utils/mock-news.json');
+            const mockData = JSON.parse(fs.readFileSync(mockDataPath, 'utf8'));
+            
+            // Add sentiment to mock data
+            const formattedMockData = mockData.map(article => {
+                const textToAnalyze = `${article.title} ${article.summary}`;
+                const sentimentResult = analyzeSentiment(textToAnalyze);
+                return {
+                    ...article,
+                    sentimentScore: sentimentResult.score,
+                    sentimentCategory: sentimentResult.category
+                };
+            });
+            
+            return res.json({ articles: formattedMockData });
+        }
+
         const apiKey = process.env.NEWS_API_KEY;
         
         if (!apiKey) {
@@ -12,7 +82,10 @@ router.get('/:country', async (req, res) => {
         }
 
         // Construct the NewsData.io API URL
-        const url = `https://newsdata.io/api/1/news?apikey=${apiKey}&country=${country}`;
+        let url = `https://newsdata.io/api/1/news?apikey=${apiKey}&country=${country}`;
+        if (category) {
+            url += `&category=${category}`;
+        }
         
         const response = await fetch(url);
         const data = await response.json();
@@ -26,13 +99,22 @@ router.get('/:country', async (req, res) => {
             });
         }
 
-        // Format the response to send only necessary fields to the frontend
-        const formattedNews = (data.results || []).map(article => ({
-            title: article.title,
-            summary: article.description || article.content || 'No summary available.',
-            url: article.link,
-            image: article.image_url || null
-        }));
+        // Format the response to send only necessary fields to the frontend and calculate sentiment
+        const formattedNews = (data.results || []).map(article => {
+            const title = article.title;
+            const summary = article.description || article.content || 'No summary available.';
+            const textToAnalyze = `${title} ${summary}`;
+            const sentimentResult = analyzeSentiment(textToAnalyze);
+
+            return {
+                title: title,
+                summary: summary,
+                url: article.link,
+                image: article.image_url || null,
+                sentimentScore: sentimentResult.score,
+                sentimentCategory: sentimentResult.category
+            };
+        });
 
         res.json({ articles: formattedNews });
 

--- a/utils/mock-news.json
+++ b/utils/mock-news.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "[MOCK] Global Markets Rally on Tech Earnings",
+    "summary": "This is a mock summary for a news article. Tech stocks led a global market rally today following stronger-than-expected earnings reports from major sector players.",
+    "url": "https://example.com/news/1",
+    "image": "https://picsum.photos/400/200?random=1"
+  },
+  {
+    "title": "[MOCK] New Sustainable Energy Policy Announced",
+    "summary": "The government has announced a comprehensive new policy aimed at transitioning to 100% renewable energy by 2050, highlighting investments in solar and wind.",
+    "url": "https://example.com/news/2",
+    "image": "https://picsum.photos/400/200?random=2"
+  },
+  {
+    "title": "[MOCK] Breakthrough in Quantum Computing Achieved",
+    "summary": "Researchers at a leading university have announced a significant breakthrough in quantum computing stability, potentially bringing commercial applications years closer.",
+    "url": "https://example.com/news/3",
+    "image": "https://picsum.photos/400/200?random=3"
+  },
+  {
+    "title": "[MOCK] Local Sports Team Wins Championship",
+    "summary": "In an unexpected turn of events, the underdog local sports team secured the championship title after a nail-biting final match that went into overtime.",
+    "url": "https://example.com/news/4",
+    "image": "https://picsum.photos/400/200?random=4"
+  },
+  {
+    "title": "[MOCK] Space Telescope Captures Stunning New Nebula",
+    "summary": "The newly deployed space telescope has transmitted its first high-resolution images back to Earth, featuring a breathtaking and previously unseen nebula.",
+    "url": "https://example.com/news/5",
+    "image": "https://picsum.photos/400/200?random=5"
+  }
+]

--- a/utils/sentiment.js
+++ b/utils/sentiment.js
@@ -1,0 +1,27 @@
+const Sentiment = require('sentiment');
+const sentiment = new Sentiment();
+
+/**
+ * Analyzes the text and returns a sentiment score and category.
+ * @param {string} text - The text to analyze (e.g., article title + summary)
+ * @returns {object} { score: number, category: string }
+ */
+function analyzeSentiment(text) {
+    if (!text) {
+        return { score: 0, category: 'Neutral' };
+    }
+
+    const result = sentiment.analyze(text);
+    const score = result.score;
+    
+    let category = 'Neutral';
+    if (score > 1) {
+        category = 'Positive';
+    } else if (score < -1) {
+        category = 'Negative';
+    }
+
+    return { score, category };
+}
+
+module.exports = { analyzeSentiment };


### PR DESCRIPTION
This pull request introduces a new interactive world news sentiment dashboard, featuring a D3-powered world map with sentiment coloring, a trending news sidebar, and a modern dashboard layout. It adds backend endpoints to provide country-level sentiment data and calculates sentiment for news articles using the `sentiment` package. The frontend is refactored to support country selection, dynamic news fetching, and sentiment-based styling.

**Frontend Dashboard & Visualization:**

* Added a new D3-based `WorldMap.vue` component that loads an SVG world map, colors each country by sentiment (Positive/Negative/Neutral/No Data), provides zoom controls, tooltips, and emits country selection events to the parent. (`frontend/src/components/WorldMap.vue`, `frontend/package.json` for `d3` dependency) [[1]](diffhunk://#diff-814410d139dd3130a1e66dec1b8ecfa8d9a8dab51568e3ddc56aad9fbf6105c3R1-R277) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R13)
* Refactored `App.vue` to implement a dashboard layout with a sidebar, top navbar, stat cards, and a news feed. Integrates the new `WorldMap` component and handles country selection, news fetching, and sentiment-based UI styling for news articles. (`frontend/src/App.vue`)
* Updated global styles and layout to support the new dashboard design and ensure full viewport usage. (`frontend/src/style.css`)

**Backend API & Sentiment Analysis:**

* Added a new `/api/news/summary` endpoint that returns mock sentiment categories for a set of countries, used to color the map. Validates allowed categories. (`routes/news.js`)
* Enhanced `/api/news/:country` endpoint to support category filtering, mock data (with sentiment analysis), and returns each article with a computed sentiment score and category. (`routes/news.js`) [[1]](diffhunk://#diff-8719cfe8f65b12688b49890efa5875990c62aaba486bffa7125b03bac630e5a9R3-R88) [[2]](diffhunk://#diff-8719cfe8f65b12688b49890efa5875990c62aaba486bffa7125b03bac630e5a9L29-R117)
* Added the `sentiment` npm package for backend sentiment analysis. (`package.json`)

These changes collectively provide a visually engaging, interactive way to explore global news sentiment, with real-time sentiment coloring and detailed news per country.